### PR TITLE
Decode URLs in tiddler filenames so Reference field isn't full of garbage

### DIFF
--- a/anki-plugin/src/twimport.py
+++ b/anki-plugin/src/twimport.py
@@ -10,6 +10,7 @@ import requests
 import subprocess
 from tempfile import TemporaryDirectory
 from typing import Callable, Optional, Set, Sequence
+import urllib
 
 from bs4 import BeautifulSoup
 
@@ -85,7 +86,8 @@ def _notes_from_paths(
     for index, tiddler in enumerate(paths, 0):
         with open(tiddler, 'rb') as f:
             tid_text = f.read().decode()
-        tid_name = tiddler.name[:tiddler.name.find(f".{RENDERED_FILE_EXTENSION}")]
+        tid_name = urllib.parse.unquote(
+            tiddler.name[:tiddler.name.find(f".{RENDERED_FILE_EXTENSION}")])
         notes.update(_notes_from_tiddler(tid_text, wiki_name, tid_name))
 
         if callback is not None and not index % 50:

--- a/ankiweb-description.html
+++ b/ankiweb-description.html
@@ -1,0 +1,16 @@
+TiddlyRemember is a tool that integrates <a href="https://tiddlywiki.com" rel="nofollow">TiddlyWiki</a> with Anki. You can interleave questions with your notes in TiddlyWiki, then sync them into Anki notes with one click. You can edit and move the questions around your TiddlyWiki, and they will stay connected to the Anki notes. Scheduling information in Anki is preserved when editing notes in TiddlyWiki.
+
+This is TiddlyRemember version 1.1.1.
+
+<ul><li><b>Documentation</b>: <a href="https://sobjornstad.github.io/TiddlyRemember/" rel="nofollow">https://sobjornstad.github.io/TiddlyRemember/</a></li>
+<li><b>Bug reports and feature requests</b>: <a href="https://github.com/sobjornstad/TiddlyRemember/issues" rel="nofollow">https://github.com/sobjornstad/TiddlyRemember/issues</a>, or email anki@sorenbjornstad.com.</li></ul>
+
+<i>This add-on does not do anything useful without also installing the TiddlyWiki plugin to your wiki.</i> Please see the documentation linked above for details on complete installation.
+
+Please do not post reviews reporting issues or asking for help, as I have no way to respond to them.
+
+<b>Changelog:</b>
+
+<ul><li><b>1.1.1</b>: Fixed a bug introduced in version 1.0.1 where tiddler titles were not URL-decoded when necessary, leading to garbage in the Reference field.</li>
+<li><b>1.1.0</b>: Fixed a bug introduced in Anki 2.1.28 where notes would not be deleted during a sync. Add <a href="https://sobjornstad.github.io/TiddlyRemember/#Soft%20and%20hard%20references" rel="nofollow">hard reference targets</a>.</li>
+<li><b>1.0.1</b>: Fixed a bug where wikis containing tiddlers whose titles contained characters invalid in a Windows filename would fail to sync on Windows.</li></ul>

--- a/docs/tiddlers/TiddlyRemember Metadata.json
+++ b/docs/tiddlers/TiddlyRemember Metadata.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.1.1",
     "compatible-tw5": ">= 5.1.21",
     "compatible-anki": ">= 2.1.28",
     "repository": "https://github.com/sobjornstad/TiddlyRemember",

--- a/docs/tiddlers/TiddlyRemember Metadata.json.meta
+++ b/docs/tiddlers/TiddlyRemember Metadata.json.meta
@@ -1,5 +1,5 @@
 created: 20200523155125699
-modified: 20200731040206195
+modified: 20200803212316247
 tags: 
 title: TiddlyRemember Metadata
 type: application/json

--- a/docs/tiddlers/TiddlyRemember.tid
+++ b/docs/tiddlers/TiddlyRemember.tid
@@ -1,6 +1,6 @@
 created: 20200523154559237
 list: [[Installing TiddlyRemember]] [[Configuring TiddlyRemember]] [[Creating notes in TiddlyRemember]] [[Syncing TiddlyRemember with Anki]]
-modified: 20200731032650251
+modified: 20200803212322689
 title: TiddlyRemember
 type: text/vnd.tiddlywiki
 

--- a/tw-plugin/plugin.info
+++ b/tw-plugin/plugin.info
@@ -2,7 +2,7 @@
     "title": "$:/plugins/sobjornstad/TiddlyRemember",
     "description": "TiddlyRemember: Embed Anki notes in your TiddlyWiki",
     "author": "Soren Bjornstad",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "core-version": ">=5.1.21",
     "source": "https://github.com/sobjornstad/TiddlyRemember",
     "list": "readme license",


### PR DESCRIPTION
See associated commit 2dead654 for details.