### PR TITLE
Support to extra field in Cloze note type

### DIFF
--- a/anki-plugin/src/trmodels.py
+++ b/anki-plugin/src/trmodels.py
@@ -326,6 +326,10 @@ class TiddlyRememberCloze(ModelData):
         back = """
             {{cloze:Text}}
 
+            <br>
+
+            {{Extra}}
+
             <div class="note-id">
                 {{#Permalink}}
                     [<a href="{{text:Permalink}}">{{Wiki}}/{{Reference}}</a> {{ID}}]
@@ -336,8 +340,8 @@ class TiddlyRememberCloze(ModelData):
             </div>
         """
 
-    name = "TiddlyRemember Cloze v1"
-    fields = ("Text", ID_FIELD_NAME, "Wiki", "Reference", "Permalink")
+    name = "TiddlyRemember Cloze v2"
+    fields = ("Text", "Extra", ID_FIELD_NAME, "Wiki", "Reference", "Permalink")
     templates = (TiddlyRememberClozeTemplate,)
     styling = """
         .card {

--- a/tw-plugin/macros/remember.tid
+++ b/tw-plugin/macros/remember.tid
@@ -46,48 +46,52 @@ type: text/vnd.tiddlywiki
     </div>
 \end
 
-\define remembercz(id, text, mode: "block", reference: "")
-	<$list filter="[[$mode$]match[inline]]" variable=_>
-		<$macrocall $name=twRememberClozeInline id=<<__id__>> text=<<__text__>> reference=<<__reference__>>/>
-	</$list>
-	<$list filter="[[$mode$]!match[inline]]" variable=_>
-		<$macrocall $name=twRememberClozeBlock id=<<__id__>> text=<<__text__>> reference=<<__reference__>>/>
-	</$list>
+\define remembercz(id, text, extra: "",mode: "block", reference: "")
+        <$list filter="[[$mode$]match[inline]]" variable=_>
+                <$macrocall $name=twRememberClozeInline id=<<__id__>> text=<<__text__>> extra=<<__extra__>> reference=<<__reference__>>/>
+        </$list>
+        <$list filter="[[$mode$]!match[inline]]" variable=_>
+                <$macrocall $name=twRememberClozeBlock id=<<__id__>> text=<<__text__>>  extra=<<__extra__>> reference=<<__reference__>>/>
+        </$list>
 \end
 
-\define twRememberClozeBlock(id, text, reference)
-	<div class="remembercz">
-		<span class="cloze-identifier">cloze: </span>
-		<span class="cloze-text">$text$</span>
-		<div class="tr-selfidentification">
-			<$set name="selfid" filter="""[enlist[$reference$]]""" value="""[<$link to="$reference$">$reference$</$link>: $id$]""" emptyValue="[$id$]">
-				<<selfid>>
-			</$set>
-		</div>
-		<div class="rid">
-			[$id$]
-		</div>
-		<div class="tr-reference">
-			<$text text=<<__reference__>>/>
-		</div>
-	</div>
+\define twRememberClozeBlock(id, text, extra, reference)
+        <div class="remembercz">
+                <span class="cloze-identifier">cloze: </span>
+                <span class="cloze-text">$text$</span><br>
+                <span class="cloze-identifier">extra: </span>
+                <span class="cloze-extra">$extra$</span>
+                <div class="tr-selfidentification">
+                        <$set name="selfid" filter="""[enlist[$reference$]]""" value="""[<$link to="$reference$">$reference$</$link>: $id$]""" emptyValue="[$id$]">
+                                <<selfid>>
+                        </$set>
+                </div>
+                <div class="rid">
+                        [$id$]
+                </div>
+                <div class="tr-reference">
+                        <$text text=<<__reference__>>/>
+                </div>
+        </div>
 \end
 
-\define twRememberClozeInline(id, text, reference)
-	<span class="remembercz">
-		<span class="cloze-identifier">{cloze: </span>
-		<span class="cloze-text">$text$</span>
-		<span class="cloze-identifier">}</span>
-		<div class="tr-selfidentification">
-			<$set name="selfid" filter="""[enlist[$reference$]]""" value="""[<$link to="$reference$">$reference$</$link>: $id$]""" emptyValue="[$id$]">
-				<<selfid>>
-			</$set>
-		</div>
-		<div class="rid">
-			[$id$]
-		</div>
-		<div class="tr-reference">
-			<$text text=<<__reference__>>/>
-		</div>
-	</span>
+\define twRememberClozeInline(id, text, extra, reference)
+        <span class="remembercz">
+                <span class="cloze-identifier">{cloze: </span>
+                <span class="cloze-text">$text$</span><br>
+                <span class="cloze-identifier">extra: </span>
+                <span class="cloze-extra">$extra$</span>
+                <span class="cloze-identifier">}</span>
+                <div class="tr-selfidentification">
+                        <$set name="selfid" filter="""[enlist[$reference$]]""" value="""[<$link to="$reference$">$reference$</$link>: $id$]""" emptyValue="[$id$]">
+                                <<selfid>>
+                        </$set>
+                </div>
+                <div class="rid">
+                        [$id$]
+                </div>
+                <div class="tr-reference">
+                        <$text text=<<__reference__>>/>
+                </div>
+        </span>
 \end

--- a/tw-plugin/stylesheets/remember.css
+++ b/tw-plugin/stylesheets/remember.css
@@ -29,6 +29,9 @@ div.remembercz {
 
 .remembercz > span.cloze-identifier {
 	color: <<colour tag-background>>;
+
+.remembercz > span.cloze-extra {
+          font-style: italic;
 }
 
 .remembercz div.tr-selfidentification {


### PR DESCRIPTION
Quick (and dirty) implementation of #36. 

- Anki plugin: add Extra field to the TiddlyRemember Cloze note type (v2).
- Tiddlywiki plugin: add `extra` parameter to the `remembercz` macro.